### PR TITLE
Improve performance of Parse

### DIFF
--- a/event_handler.go
+++ b/event_handler.go
@@ -66,4 +66,7 @@ type AnsiEventHandler interface {
 
 	// Reverse Index
 	RI() error
+
+	// Flush updates from previous commands
+	Flush() error
 }

--- a/ground_state.go
+++ b/ground_state.go
@@ -5,7 +5,6 @@ type GroundState struct {
 }
 
 func (gs GroundState) Handle(b byte) (s State, e error) {
-	logger.Infof("Ground::Handle %#x", b)
 	gs.parser.context.currentChar = b
 
 	nextState, err := gs.BaseState.Handle(b)

--- a/parser.go
+++ b/parser.go
@@ -87,7 +87,7 @@ func (ap *AnsiParser) Parse(bytes []byte) (int, error) {
 		}
 	}
 
-	return len(bytes), nil
+	return len(bytes), ap.eventHandler.Flush()
 }
 
 func (ap *AnsiParser) handle(b byte) error {

--- a/parser_actions.go
+++ b/parser_actions.go
@@ -95,7 +95,6 @@ func (ap *AnsiParser) csiDispatch() error {
 }
 
 func (ap *AnsiParser) print() error {
-	logger.Infof("AnsiParser::print %#x", ap.context.currentChar)
 	return ap.eventHandler.Print(ap.context.currentChar)
 }
 
@@ -105,8 +104,5 @@ func (ap *AnsiParser) clear() error {
 }
 
 func (ap *AnsiParser) execute() error {
-	logger.Infof("AnsiParser::execute %#x", ap.context.currentChar)
-
 	return ap.eventHandler.Execute(ap.context.currentChar)
-
 }

--- a/test_event_handler.go
+++ b/test_event_handler.go
@@ -137,3 +137,7 @@ func (h *TestAnsiEventHandler) RI() error {
 	h.recordCall("RI", nil)
 	return nil
 }
+
+func (h *TestAnsiEventHandler) Flush() error {
+	return nil
+}


### PR DESCRIPTION
These commits dramatically improve the performance of Parse() and address issues #2 and #3. This work was the result of using go profiling, and each of the four changes makes a multi-second difference in running dir in windows\system32 (using Windows Server Containers in docker). With the changes, console speed seems quite reasonable.

The commits are mostly independent. The controversial aspects of these changes are:
1. How I incorporated the buffering for Print (by adding a new Flush function to State). I didn't feel comfortable using the existing Exit because we need to flush when there is no more data and technically we are not exiting the ground state in this case. I also didn't feel great hard-coding the flush behavior into Parse. Feedback is welcome.
2. I removed the special line feed handing from Execute(). Windows seems to scroll the console just fine without help, and the extra line erase seems incorrect -- I couldn't find any docs that indicate that LF is supposed to erase characters.
3. I now treat CR and LF as printable characters to improve batching further. They're not technically printable, but the windows console handles them fine without special handing (modulo any bugs I introduced from 2).

@jhowardmsft FYI
