### PR TITLE
Treat 0 as the default value when parsing params

### DIFF
--- a/parser_action_helpers.go
+++ b/parser_action_helpers.go
@@ -46,6 +46,10 @@ func getInts(params []string, minCount int, dflt int) []int {
 
 	for _, v := range params {
 		i, _ := strconv.Atoi(v)
+		// Zero is mapped to the default value in VT100.
+		if i == 0 {
+			i = dflt
+		}
 		ints = append(ints, i)
 	}
 

--- a/parser_test_helpers.go
+++ b/parser_test_helpers.go
@@ -64,6 +64,7 @@ func parseParamsHelper(t *testing.T, bytes []byte, expectedParams []string) {
 
 func cursorSingleParamHelper(t *testing.T, command byte, funcName string) {
 	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
+	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
 	funcCallParamHelper(t, []byte{'2', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2])", funcName)})
 	funcCallParamHelper(t, []byte{'2', '3', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([23])", funcName)})
 	funcCallParamHelper(t, []byte{'2', ';', '3', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2])", funcName)})
@@ -72,6 +73,7 @@ func cursorSingleParamHelper(t *testing.T, command byte, funcName string) {
 
 func cursorTwoParamHelper(t *testing.T, command byte, funcName string) {
 	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1 1])", funcName)})
+	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1 1])", funcName)})
 	funcCallParamHelper(t, []byte{'2', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2 1])", funcName)})
 	funcCallParamHelper(t, []byte{'2', '3', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([23 1])", funcName)})
 	funcCallParamHelper(t, []byte{'2', ';', '3', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2 3])", funcName)})
@@ -90,7 +92,7 @@ func eraseHelper(t *testing.T, command byte, funcName string) {
 
 func scrollHelper(t *testing.T, command byte, funcName string) {
 	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
-	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([0])", funcName)})
+	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
 	funcCallParamHelper(t, []byte{'1', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
 	funcCallParamHelper(t, []byte{'5', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([5])", funcName)})
 	funcCallParamHelper(t, []byte{'4', ';', '6', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([4])", funcName)})


### PR DESCRIPTION
This matches the VT510 specification and fixes some issues
with vttest.

Signed-off-by: John Starks jostarks@microsoft.com
