### PR TITLE
Fix import to point the github.com and not github.com/docker/docker

### DIFF
--- a/winterm/ansi.go
+++ b/winterm/ansi.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"syscall"
 
-	. "github.com/docker/docker/vendor/src/github.com/Azure/go-ansiterm"
+	. "github.com/Azure/go-ansiterm"
 )
 
 // Windows keyboard constants


### PR DESCRIPTION
I'm guessing this was just a goimport gone wrong and you really wanted to point to `github.com/Azure/go-ansiterm`.  I noticed this when trying to vendor this code.
