### PR TITLE
Add VPA command for emacs

### DIFF
--- a/event_handler.go
+++ b/event_handler.go
@@ -28,6 +28,9 @@ type AnsiEventHandler interface {
 	// Cursor Horizontal position Absolute
 	CHA(int) error
 
+	// Vertical line Position Absolute
+	VPA(int) error
+
 	// CUrsor Position
 	CUP(int, int) error
 

--- a/parser_actions.go
+++ b/parser_actions.go
@@ -73,6 +73,8 @@ func (ap *AnsiParser) csiDispatch() error {
 		return ap.eventHandler.SD(getInt(params, 1))
 	case "c":
 		return ap.eventHandler.DA(params)
+	case "d":
+		return ap.eventHandler.VPA(getInt(params, 1))
 	case "f":
 		ints := getInts(params, 2, 1)
 		x, y := ints[0], ints[1]

--- a/test_event_handler.go
+++ b/test_event_handler.go
@@ -65,6 +65,11 @@ func (h *TestAnsiEventHandler) CHA(param int) error {
 	return nil
 }
 
+func (h *TestAnsiEventHandler) VPA(param int) error {
+	h.recordCall("VPA", []string{strconv.Itoa(param)})
+	return nil
+}
+
 func (h *TestAnsiEventHandler) CUP(x int, y int) error {
 	xS, yS := strconv.Itoa(x), strconv.Itoa(y)
 	h.recordCall("CUP", []string{xS, yS})

--- a/winterm/win_event_handler.go
+++ b/winterm/win_event_handler.go
@@ -155,6 +155,20 @@ func (h *WindowsAnsiEventHandler) CHA(param int) error {
 	return h.moveCursorColumn(param)
 }
 
+func (h *WindowsAnsiEventHandler) VPA(param int) error {
+	if err := h.Flush(); err != nil {
+		return err
+	}
+	logger.Infof("VPA: [[%d]]", param)
+	info, err := GetConsoleScreenBufferInfo(h.fd)
+	if err != nil {
+		return err
+	}
+	pos := info.CursorPosition
+	pos.Y = ensureInRange(SHORT(param-1), info.Window.Top, info.Window.Bottom)
+	return SetConsoleCursorPosition(h.fd, pos)
+}
+
 func (h *WindowsAnsiEventHandler) CUP(row int, col int) error {
 	if err := h.Flush(); err != nil {
 		return err


### PR DESCRIPTION
This command is used by emacs to set the current line without affecting the horizontal position.

Note that this change is necessary but insufficient to get emacs working even reasonably well.
