### PR TITLE
Clear inverse mode on SGR reset

### DIFF
--- a/winterm/win_event_handler.go
+++ b/winterm/win_event_handler.go
@@ -341,6 +341,7 @@ func (h *WindowsAnsiEventHandler) SGR(params []int) error {
 
 			if attr == ANSI_SGR_RESET {
 				h.attributes = h.infoReset.Attributes
+				h.inverted = false
 				continue
 			}
 


### PR DESCRIPTION
This fixes a regression in nano.
