### PR TITLE
vttest commands

### DIFF
--- a/event_handler.go
+++ b/event_handler.go
@@ -40,6 +40,9 @@ type AnsiEventHandler interface {
 	// Text Cursor Enable Mode
 	DECTCEM(bool) error
 
+	// Origin Mode
+	DECOM(bool) error
+
 	// Erase in Display
 	ED(int) error
 

--- a/event_handler.go
+++ b/event_handler.go
@@ -73,6 +73,9 @@ type AnsiEventHandler interface {
 	// Set Top and Bottom Margins
 	DECSTBM(int, int) error
 
+	// Index
+	IND() error
+
 	// Reverse Index
 	RI() error
 

--- a/event_handler.go
+++ b/event_handler.go
@@ -43,6 +43,9 @@ type AnsiEventHandler interface {
 	// Origin Mode
 	DECOM(bool) error
 
+	// 132 Column Mode
+	DECCOLM(bool) error
+
 	// Erase in Display
 	ED(int) error
 

--- a/parser_action_helpers.go
+++ b/parser_action_helpers.go
@@ -65,17 +65,27 @@ func getInts(params []string, minCount int, dflt int) []int {
 	return ints
 }
 
+func (ap *AnsiParser) modeDispatch(param string, set bool) error {
+	switch param {
+	case "?6":
+		return ap.eventHandler.DECOM(set)
+	case "?25":
+		return ap.eventHandler.DECTCEM(set)
+	}
+	return nil
+}
+
 func (ap *AnsiParser) hDispatch(params []string) error {
-	if len(params) == 1 && params[0] == "?25" {
-		return ap.eventHandler.DECTCEM(true)
+	if len(params) == 1 {
+		return ap.modeDispatch(params[0], true)
 	}
 
 	return nil
 }
 
 func (ap *AnsiParser) lDispatch(params []string) error {
-	if len(params) == 1 && params[0] == "?25" {
-		return ap.eventHandler.DECTCEM(false)
+	if len(params) == 1 {
+		return ap.modeDispatch(params[0], false)
 	}
 
 	return nil

--- a/parser_action_helpers.go
+++ b/parser_action_helpers.go
@@ -67,6 +67,8 @@ func getInts(params []string, minCount int, dflt int) []int {
 
 func (ap *AnsiParser) modeDispatch(param string, set bool) error {
 	switch param {
+	case "?3":
+		return ap.eventHandler.DECCOLM(set)
 	case "?6":
 		return ap.eventHandler.DECOM(set)
 	case "?25":

--- a/parser_actions.go
+++ b/parser_actions.go
@@ -25,7 +25,15 @@ func (ap *AnsiParser) escDispatch() error {
 	logger.Infof("escDispatch: %v(%v)", cmd, intermeds)
 
 	switch cmd {
-	case "M":
+	case "D": // IND
+		return ap.eventHandler.IND()
+	case "E": // NEL, equivalent to CRLF
+		err := ap.eventHandler.Execute(ANSI_CARRIAGE_RETURN)
+		if err == nil {
+			err = ap.eventHandler.Execute(ANSI_LINE_FEED)
+		}
+		return err
+	case "M": // RI
 		return ap.eventHandler.RI()
 	}
 

--- a/test_event_handler.go
+++ b/test_event_handler.go
@@ -92,6 +92,11 @@ func (h *TestAnsiEventHandler) DECOM(visible bool) error {
 	return nil
 }
 
+func (h *TestAnsiEventHandler) DECCOLM(use132 bool) error {
+	h.recordCall("DECOLM", []string{strconv.FormatBool(use132)})
+	return nil
+}
+
 func (h *TestAnsiEventHandler) ED(param int) error {
 	h.recordCall("ED", []string{strconv.Itoa(param)})
 	return nil

--- a/test_event_handler.go
+++ b/test_event_handler.go
@@ -153,6 +153,11 @@ func (h *TestAnsiEventHandler) RI() error {
 	return nil
 }
 
+func (h *TestAnsiEventHandler) IND() error {
+	h.recordCall("IND", nil)
+	return nil
+}
+
 func (h *TestAnsiEventHandler) Flush() error {
 	return nil
 }

--- a/test_event_handler.go
+++ b/test_event_handler.go
@@ -87,6 +87,11 @@ func (h *TestAnsiEventHandler) DECTCEM(visible bool) error {
 	return nil
 }
 
+func (h *TestAnsiEventHandler) DECOM(visible bool) error {
+	h.recordCall("DECOM", []string{strconv.FormatBool(visible)})
+	return nil
+}
+
 func (h *TestAnsiEventHandler) ED(param int) error {
 	h.recordCall("ED", []string{strconv.Itoa(param)})
 	return nil

--- a/winterm/cursor_helpers.go
+++ b/winterm/cursor_helpers.go
@@ -7,11 +7,35 @@ const (
 	Vertical
 )
 
-// setCursorPosition sets the cursor to the specified position, bounded to the buffer size
-func (h *WindowsAnsiEventHandler) setCursorPosition(position COORD, sizeBuffer COORD) error {
-	position.X = ensureInRange(position.X, 0, sizeBuffer.X-1)
-	position.Y = ensureInRange(position.Y, 0, sizeBuffer.Y-1)
-	return SetConsoleCursorPosition(h.fd, position)
+func (h *WindowsAnsiEventHandler) getCursorWindow(info *CONSOLE_SCREEN_BUFFER_INFO) SMALL_RECT {
+	if h.originMode {
+		sr := h.effectiveSr(info.Window)
+		return SMALL_RECT{
+			Top:    sr.top,
+			Bottom: sr.bottom,
+			Left:   0,
+			Right:  info.Size.X - 1,
+		}
+	} else {
+		return SMALL_RECT{
+			Top:    info.Window.Top,
+			Bottom: info.Window.Bottom,
+			Left:   0,
+			Right:  info.Size.X - 1,
+		}
+	}
+}
+
+// setCursorPosition sets the cursor to the specified position, bounded to the screen size
+func (h *WindowsAnsiEventHandler) setCursorPosition(position COORD, window SMALL_RECT) error {
+	position.X = ensureInRange(position.X, window.Left, window.Right)
+	position.Y = ensureInRange(position.Y, window.Top, window.Bottom)
+	err := SetConsoleCursorPosition(h.fd, position)
+	if err != nil {
+		return err
+	}
+	logger.Infof("Cursor position set: (%d, %d)", position.X, position.Y)
+	return err
 }
 
 func (h *WindowsAnsiEventHandler) moveCursorVertical(param int) error {
@@ -31,16 +55,14 @@ func (h *WindowsAnsiEventHandler) moveCursor(moveMode int, param int) error {
 	position := info.CursorPosition
 	switch moveMode {
 	case Horizontal:
-		position.X = AddInRange(position.X, SHORT(param), 0, info.Size.X-1)
+		position.X += SHORT(param)
 	case Vertical:
-		position.Y = AddInRange(position.Y, SHORT(param), info.Window.Top, info.Window.Bottom)
+		position.Y += SHORT(param)
 	}
 
-	if err = h.setCursorPosition(position, info.Size); err != nil {
+	if err = h.setCursorPosition(position, h.getCursorWindow(info)); err != nil {
 		return err
 	}
-
-	logger.Infof("Cursor position set: (%d, %d)", position.X, position.Y)
 
 	return nil
 }
@@ -53,9 +75,9 @@ func (h *WindowsAnsiEventHandler) moveCursorLine(param int) error {
 
 	position := info.CursorPosition
 	position.X = 0
-	position.Y = AddInRange(position.Y, SHORT(param), info.Window.Top, info.Window.Bottom)
+	position.Y += SHORT(param)
 
-	if err = h.setCursorPosition(position, info.Size); err != nil {
+	if err = h.setCursorPosition(position, h.getCursorWindow(info)); err != nil {
 		return err
 	}
 
@@ -69,9 +91,9 @@ func (h *WindowsAnsiEventHandler) moveCursorColumn(param int) error {
 	}
 
 	position := info.CursorPosition
-	position.X = AddInRange(SHORT(param), -1, 0, info.Size.X-1)
+	position.X = SHORT(param) - 1
 
-	if err = h.setCursorPosition(position, info.Size); err != nil {
+	if err = h.setCursorPosition(position, h.getCursorWindow(info)); err != nil {
 		return err
 	}
 

--- a/winterm/win_event_handler.go
+++ b/winterm/win_event_handler.go
@@ -613,6 +613,11 @@ func (h *WindowsAnsiEventHandler) RI() error {
 	}
 }
 
+func (h *WindowsAnsiEventHandler) IND() error {
+	logger.Info("IND: []")
+	return h.executeLF()
+}
+
 func (h *WindowsAnsiEventHandler) Flush() error {
 	h.curInfo = nil
 	if h.buffer.Len() > 0 {


### PR DESCRIPTION
This change adds a few commands necessary for some basic vttest tests to (nearly) pass: DECOM, DECOLM, IND, and NEL.
