### PR TITLE
fix casing in import statement

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var logger *logrus.Logger

--- a/winterm/win_event_handler.go
+++ b/winterm/win_event_handler.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/Azure/go-ansiterm"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var logger *logrus.Logger


### PR DESCRIPTION
This library is causing us to have two folders in our vendor called `Sirupsen` and `sirupsen`. According to the [sirupsen/logrus's README](https://github.com/sirupsen/logrus/blob/master/README.md):

> Everything using logrus will need to use the lower-case: github.com/sirupsen/logrus. Any package that isn't, should be changed.

Fixing these import statements would save us some duplication.