### PR TITLE
update to github.com/sirupsen/logrus v1.0.0

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var logger *logrus.Logger

--- a/winterm/win_event_handler.go
+++ b/winterm/win_event_handler.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 
 	"github.com/Azure/go-ansiterm"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var logger *logrus.Logger


### PR DESCRIPTION
Signed-off-by: Andrew Pennebaker <apennebaker@datapipe.com>

Fix some dependencies by updating logrus, which has moved from github.com/Sirupsen/logrus to github.com/sirupsen/logrus.