### PR TITLE
Remove logrus dependency, and add functional options to specify logger

### DIFF
--- a/csi_entry_state.go
+++ b/csi_entry_state.go
@@ -5,7 +5,7 @@ type csiEntryState struct {
 }
 
 func (csiState csiEntryState) Handle(b byte) (s state, e error) {
-	logger.Infof("CsiEntry::Handle %#x", b)
+	csiState.parser.logf("CsiEntry::Handle %#x", b)
 
 	nextState, err := csiState.baseState.Handle(b)
 	if nextState != nil || err != nil {
@@ -25,7 +25,7 @@ func (csiState csiEntryState) Handle(b byte) (s state, e error) {
 }
 
 func (csiState csiEntryState) Transition(s state) error {
-	logger.Infof("CsiEntry::Transition %s --> %s", csiState.Name(), s.Name())
+	csiState.parser.logf("CsiEntry::Transition %s --> %s", csiState.Name(), s.Name())
 	csiState.baseState.Transition(s)
 
 	switch s {

--- a/csi_param_state.go
+++ b/csi_param_state.go
@@ -5,7 +5,7 @@ type csiParamState struct {
 }
 
 func (csiState csiParamState) Handle(b byte) (s state, e error) {
-	logger.Infof("CsiParam::Handle %#x", b)
+	csiState.parser.logf("CsiParam::Handle %#x", b)
 
 	nextState, err := csiState.baseState.Handle(b)
 	if nextState != nil || err != nil {
@@ -26,7 +26,7 @@ func (csiState csiParamState) Handle(b byte) (s state, e error) {
 }
 
 func (csiState csiParamState) Transition(s state) error {
-	logger.Infof("CsiParam::Transition %s --> %s", csiState.Name(), s.Name())
+	csiState.parser.logf("CsiParam::Transition %s --> %s", csiState.Name(), s.Name())
 	csiState.baseState.Transition(s)
 
 	switch s {

--- a/escape_intermediate_state.go
+++ b/escape_intermediate_state.go
@@ -5,7 +5,7 @@ type escapeIntermediateState struct {
 }
 
 func (escState escapeIntermediateState) Handle(b byte) (s state, e error) {
-	logger.Infof("escapeIntermediateState::Handle %#x", b)
+	escState.parser.logf("escapeIntermediateState::Handle %#x", b)
 	nextState, err := escState.baseState.Handle(b)
 	if nextState != nil || err != nil {
 		return nextState, err
@@ -24,7 +24,7 @@ func (escState escapeIntermediateState) Handle(b byte) (s state, e error) {
 }
 
 func (escState escapeIntermediateState) Transition(s state) error {
-	logger.Infof("escapeIntermediateState::Transition %s --> %s", escState.Name(), s.Name())
+	escState.parser.logf("escapeIntermediateState::Transition %s --> %s", escState.Name(), s.Name())
 	escState.baseState.Transition(s)
 
 	switch s {

--- a/escape_state.go
+++ b/escape_state.go
@@ -5,7 +5,7 @@ type escapeState struct {
 }
 
 func (escState escapeState) Handle(b byte) (s state, e error) {
-	logger.Infof("escapeState::Handle %#x", b)
+	escState.parser.logf("escapeState::Handle %#x", b)
 	nextState, err := escState.baseState.Handle(b)
 	if nextState != nil || err != nil {
 		return nextState, err
@@ -28,7 +28,7 @@ func (escState escapeState) Handle(b byte) (s state, e error) {
 }
 
 func (escState escapeState) Transition(s state) error {
-	logger.Infof("Escape::Transition %s --> %s", escState.Name(), s.Name())
+	escState.parser.logf("Escape::Transition %s --> %s", escState.Name(), s.Name())
 	escState.baseState.Transition(s)
 
 	switch s {

--- a/osc_string_state.go
+++ b/osc_string_state.go
@@ -5,7 +5,7 @@ type oscStringState struct {
 }
 
 func (oscState oscStringState) Handle(b byte) (s state, e error) {
-	logger.Infof("OscString::Handle %#x", b)
+	oscState.parser.logf("OscString::Handle %#x", b)
 	nextState, err := oscState.baseState.Handle(b)
 	if nextState != nil || err != nil {
 		return nextState, err

--- a/parser.go
+++ b/parser.go
@@ -2,13 +2,9 @@ package ansiterm
 
 import (
 	"errors"
-	"io/ioutil"
+	"log"
 	"os"
-
-	"github.com/sirupsen/logrus"
 )
-
-var logger *logrus.Logger
 
 type AnsiParser struct {
 	currState          state
@@ -23,50 +19,69 @@ type AnsiParser struct {
 	ground             state
 	oscString          state
 	stateMap           []state
+
+	logf func(string, ...interface{})
 }
 
-func CreateParser(initialState string, evtHandler AnsiEventHandler) *AnsiParser {
-	logFile := ioutil.Discard
+type Option func(*AnsiParser)
 
-	if isDebugEnv := os.Getenv(LogEnv); isDebugEnv == "1" {
-		logFile, _ = os.Create("ansiParser.log")
+func WithLogf(f func(string, ...interface{})) Option {
+	return func(ap *AnsiParser) {
+		ap.logf = f
 	}
+}
 
-	logger = &logrus.Logger{
-		Out:       logFile,
-		Formatter: new(logrus.TextFormatter),
-		Level:     logrus.InfoLevel,
-	}
-
-	parser := &AnsiParser{
+func CreateParser(initialState string, evtHandler AnsiEventHandler, opts ...Option) *AnsiParser {
+	ap := &AnsiParser{
 		eventHandler: evtHandler,
 		context:      &ansiContext{},
 	}
-
-	parser.csiEntry = csiEntryState{baseState{name: "CsiEntry", parser: parser}}
-	parser.csiParam = csiParamState{baseState{name: "CsiParam", parser: parser}}
-	parser.dcsEntry = dcsEntryState{baseState{name: "DcsEntry", parser: parser}}
-	parser.escape = escapeState{baseState{name: "Escape", parser: parser}}
-	parser.escapeIntermediate = escapeIntermediateState{baseState{name: "EscapeIntermediate", parser: parser}}
-	parser.error = errorState{baseState{name: "Error", parser: parser}}
-	parser.ground = groundState{baseState{name: "Ground", parser: parser}}
-	parser.oscString = oscStringState{baseState{name: "OscString", parser: parser}}
-
-	parser.stateMap = []state{
-		parser.csiEntry,
-		parser.csiParam,
-		parser.dcsEntry,
-		parser.escape,
-		parser.escapeIntermediate,
-		parser.error,
-		parser.ground,
-		parser.oscString,
+	for _, o := range opts {
+		o(ap)
 	}
 
-	parser.currState = getState(initialState, parser.stateMap)
+	if isDebugEnv := os.Getenv(LogEnv); isDebugEnv == "1" {
+		logFile, _ := os.Create("ansiParser.log")
+		logger := log.New(logFile, "", log.LstdFlags)
+		if ap.logf != nil {
+			l := ap.logf
+			ap.logf = func(s string, v ...interface{}) {
+				l(s, v...)
+				logger.Printf(s, v...)
+			}
+		} else {
+			ap.logf = logger.Printf
+		}
+	}
 
-	logger.Infof("CreateParser: parser %p", parser)
-	return parser
+	if ap.logf == nil {
+		ap.logf = func(string, ...interface{}) {}
+	}
+
+	ap.csiEntry = csiEntryState{baseState{name: "CsiEntry", parser: ap}}
+	ap.csiParam = csiParamState{baseState{name: "CsiParam", parser: ap}}
+	ap.dcsEntry = dcsEntryState{baseState{name: "DcsEntry", parser: ap}}
+	ap.escape = escapeState{baseState{name: "Escape", parser: ap}}
+	ap.escapeIntermediate = escapeIntermediateState{baseState{name: "EscapeIntermediate", parser: ap}}
+	ap.error = errorState{baseState{name: "Error", parser: ap}}
+	ap.ground = groundState{baseState{name: "Ground", parser: ap}}
+	ap.oscString = oscStringState{baseState{name: "OscString", parser: ap}}
+
+	ap.stateMap = []state{
+		ap.csiEntry,
+		ap.csiParam,
+		ap.dcsEntry,
+		ap.escape,
+		ap.escapeIntermediate,
+		ap.error,
+		ap.ground,
+		ap.oscString,
+	}
+
+	ap.currState = getState(initialState, ap.stateMap)
+
+	ap.logf("CreateParser: parser %p", ap)
+	return ap
 }
 
 func getState(name string, states []state) state {
@@ -97,7 +112,7 @@ func (ap *AnsiParser) handle(b byte) error {
 	}
 
 	if newState == nil {
-		logger.Warning("newState is nil")
+		ap.logf("WARNING: newState is nil")
 		return errors.New("New state of 'nil' is invalid.")
 	}
 
@@ -111,23 +126,23 @@ func (ap *AnsiParser) handle(b byte) error {
 }
 
 func (ap *AnsiParser) changeState(newState state) error {
-	logger.Infof("ChangeState %s --> %s", ap.currState.Name(), newState.Name())
+	ap.logf("ChangeState %s --> %s", ap.currState.Name(), newState.Name())
 
 	// Exit old state
 	if err := ap.currState.Exit(); err != nil {
-		logger.Infof("Exit state '%s' failed with : '%v'", ap.currState.Name(), err)
+		ap.logf("Exit state '%s' failed with : '%v'", ap.currState.Name(), err)
 		return err
 	}
 
 	// Perform transition action
 	if err := ap.currState.Transition(newState); err != nil {
-		logger.Infof("Transition from '%s' to '%s' failed with: '%v'", ap.currState.Name(), newState.Name, err)
+		ap.logf("Transition from '%s' to '%s' failed with: '%v'", ap.currState.Name(), newState.Name, err)
 		return err
 	}
 
 	// Enter new state
 	if err := newState.Enter(); err != nil {
-		logger.Infof("Enter state '%s' failed with: '%v'", newState.Name(), err)
+		ap.logf("Enter state '%s' failed with: '%v'", newState.Name(), err)
 		return err
 	}
 

--- a/parser_action_helpers.go
+++ b/parser_action_helpers.go
@@ -27,7 +27,6 @@ func parseParams(bytes []byte) ([]string, error) {
 		params = append(params, s)
 	}
 
-	logger.Infof("Parsed params: %v with length: %d", params, len(params))
 	return params, nil
 }
 
@@ -37,7 +36,6 @@ func parseCmd(context ansiContext) (string, error) {
 
 func getInt(params []string, dflt int) int {
 	i := getInts(params, 1, dflt)[0]
-	logger.Infof("getInt: %v", i)
 	return i
 }
 
@@ -59,8 +57,6 @@ func getInts(params []string, minCount int, dflt int) []int {
 			ints = append(ints, dflt)
 		}
 	}
-
-	logger.Infof("getInts: %v", ints)
 
 	return ints
 }

--- a/parser_actions.go
+++ b/parser_actions.go
@@ -1,19 +1,15 @@
 package ansiterm
 
-import (
-	"fmt"
-)
-
 func (ap *AnsiParser) collectParam() error {
 	currChar := ap.context.currentChar
-	logger.Infof("collectParam %#x", currChar)
+	ap.logf("collectParam %#x", currChar)
 	ap.context.paramBuffer = append(ap.context.paramBuffer, currChar)
 	return nil
 }
 
 func (ap *AnsiParser) collectInter() error {
 	currChar := ap.context.currentChar
-	logger.Infof("collectInter %#x", currChar)
+	ap.logf("collectInter %#x", currChar)
 	ap.context.paramBuffer = append(ap.context.interBuffer, currChar)
 	return nil
 }
@@ -21,8 +17,8 @@ func (ap *AnsiParser) collectInter() error {
 func (ap *AnsiParser) escDispatch() error {
 	cmd, _ := parseCmd(*ap.context)
 	intermeds := ap.context.interBuffer
-	logger.Infof("escDispatch currentChar: %#x", ap.context.currentChar)
-	logger.Infof("escDispatch: %v(%v)", cmd, intermeds)
+	ap.logf("escDispatch currentChar: %#x", ap.context.currentChar)
+	ap.logf("escDispatch: %v(%v)", cmd, intermeds)
 
 	switch cmd {
 	case "D": // IND
@@ -43,8 +39,9 @@ func (ap *AnsiParser) escDispatch() error {
 func (ap *AnsiParser) csiDispatch() error {
 	cmd, _ := parseCmd(*ap.context)
 	params, _ := parseParams(ap.context.paramBuffer)
+	ap.logf("Parsed params: %v with length: %d", params, len(params))
 
-	logger.Infof("csiDispatch: %v(%v)", cmd, params)
+	ap.logf("csiDispatch: %v(%v)", cmd, params)
 
 	switch cmd {
 	case "@":
@@ -102,7 +99,7 @@ func (ap *AnsiParser) csiDispatch() error {
 		top, bottom := ints[0], ints[1]
 		return ap.eventHandler.DECSTBM(top, bottom)
 	default:
-		logger.Errorf(fmt.Sprintf("Unsupported CSI command: '%s', with full context:  %v", cmd, ap.context))
+		ap.logf("ERROR: Unsupported CSI command: '%s', with full context:  %v", cmd, ap.context)
 		return nil
 	}
 

--- a/winterm/cursor_helpers.go
+++ b/winterm/cursor_helpers.go
@@ -34,7 +34,7 @@ func (h *windowsAnsiEventHandler) setCursorPosition(position COORD, window SMALL
 	if err != nil {
 		return err
 	}
-	logger.Infof("Cursor position set: (%d, %d)", position.X, position.Y)
+	h.logf("Cursor position set: (%d, %d)", position.X, position.Y)
 	return err
 }
 

--- a/winterm/scroll_helper.go
+++ b/winterm/scroll_helper.go
@@ -50,8 +50,8 @@ func (h *windowsAnsiEventHandler) insertLines(param int) error {
 
 // scroll scrolls the provided scroll region by param lines. The scroll region is in buffer coordinates.
 func (h *windowsAnsiEventHandler) scroll(param int, sr scrollRegion, info *CONSOLE_SCREEN_BUFFER_INFO) error {
-	logger.Infof("scroll: scrollTop: %d, scrollBottom: %d", sr.top, sr.bottom)
-	logger.Infof("scroll: windowTop: %d, windowBottom: %d", info.Window.Top, info.Window.Bottom)
+	h.logf("scroll: scrollTop: %d, scrollBottom: %d", sr.top, sr.bottom)
+	h.logf("scroll: windowTop: %d, windowBottom: %d", info.Window.Top, info.Window.Bottom)
 
 	// Copy from and clip to the scroll region (full buffer width)
 	scrollRect := SMALL_RECT{


### PR DESCRIPTION
This changeset removes the non-standard dependency to logrus, leaving
the only dependencies used in ansiterm and winterm as Go standard lib
packages. This also has the added benefit of removing a superfulous
package level variable (logger) in both ansiterm and winterm.

The changes made here introduce a backwards compatible change to the
API signatures of ansiterm.CreateParser and winterm.CreateWinEventHandler
by introducing the optional functional parameters pattern on both.
Additionally, both ansiterm and winterm packages receive a WithLogf()
func to specify a logging func to use, which can be passed a func
with the standard Printf signature, ie: func(string, ...interface{}).

This maintains the existing behavior of checking for the environment
variable DEBUG_TERMINAL, and writing to the files ansiParser.log and
winEventHandler.log. For ansiterm/winterm, if a logging func has been
specified as well as having DEBUG_TERMINAL set, then both the respective
*.log file and the passed logging func will receive the data.

Note: for simplicity purposes, the single instance in ansiterm where
there was a "warning" and "error" was logged has been changed to use the
single log, but the messages have been prefixed with WARNING and ERROR
respectively. This was done entirely for simplicity reasons.
Additionally 2 other logging calls have been removed where it was
prudent to do so, and one other logging line was moved to a different
location in order to avoid changing some utility funcs.