### PR TITLE
winterm: remove addInRange() utility

### DIFF
--- a/winterm/scroll_helper.go
+++ b/winterm/scroll_helper.go
@@ -4,8 +4,8 @@ package winterm
 
 // effectiveSr gets the current effective scroll region in buffer coordinates
 func (h *windowsAnsiEventHandler) effectiveSr(window SMALL_RECT) scrollRegion {
-	top := addInRange(window.Top, h.sr.top, window.Top, window.Bottom)
-	bottom := addInRange(window.Top, h.sr.bottom, window.Top, window.Bottom)
+	top := ensureInRange(window.Top+h.sr.top, window.Top, window.Bottom)
+	bottom := ensureInRange(window.Top+h.sr.bottom, window.Top, window.Bottom)
 	if top >= bottom {
 		top = window.Top
 		bottom = window.Bottom

--- a/winterm/utilities.go
+++ b/winterm/utilities.go
@@ -1,9 +1,0 @@
-// +build windows
-
-package winterm
-
-// AddInRange increments a value by the passed quantity while ensuring the values
-// always remain within the supplied min / max range.
-func addInRange(n int16, increment int16, min int16, max int16) int16 {
-	return ensureInRange(n+increment, min, max)
-}


### PR DESCRIPTION
It was only used in a single place, and a thin wrapper for ensureInRange().
