### PR TITLE
Added compatibility with "golang.org/x/sys/windows"

### DIFF
--- a/winterm/ansi.go
+++ b/winterm/ansi.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/Azure/go-ansiterm"
+	windows "golang.org/x/sys/windows"
 )
 
 // Windows keyboard constants
@@ -164,10 +165,13 @@ func GetStdFile(nFile int) (*os.File, uintptr) {
 	var file *os.File
 	switch nFile {
 	case syscall.STD_INPUT_HANDLE:
+	case windows.STD_INPUT_HANDLE:
 		file = os.Stdin
 	case syscall.STD_OUTPUT_HANDLE:
+	case windows.STD_OUTPUT_HANDLE:
 		file = os.Stdout
 	case syscall.STD_ERROR_HANDLE:
+	case windows.STD_ERROR_HANDLE:
 		file = os.Stderr
 	default:
 		panic(fmt.Errorf("Invalid standard handle identifier: %v", nFile))


### PR DESCRIPTION
Many of the [consumers ](https://github.com/moby/term/pull/9/files)of this library use "golang.org/x/sys/windows" since it's better maintained than `syscall` package.

This has caused breaking [changes ](https://github.com/kubernetes/kubernetes/issues/102404) with several [clients ](https://github.com/docker/for-win/issues/9770)this PR fixes these issues + attempts to maintain compatibility with the clients which still use `syscall` package

@jstarks Please review :) 