### PR TITLE
winterm: fix GetStdFile() falltrough

### DIFF
--- a/winterm/ansi.go
+++ b/winterm/ansi.go
@@ -164,14 +164,11 @@ func ensureInRange(n int16, min int16, max int16) int16 {
 func GetStdFile(nFile int) (*os.File, uintptr) {
 	var file *os.File
 	switch nFile {
-	case syscall.STD_INPUT_HANDLE:
-	case windows.STD_INPUT_HANDLE:
+	case syscall.STD_INPUT_HANDLE, windows.STD_INPUT_HANDLE:
 		file = os.Stdin
-	case syscall.STD_OUTPUT_HANDLE:
-	case windows.STD_OUTPUT_HANDLE:
+	case syscall.STD_OUTPUT_HANDLE, windows.STD_OUTPUT_HANDLE:
 		file = os.Stdout
-	case syscall.STD_ERROR_HANDLE:
-	case windows.STD_ERROR_HANDLE:
+	case syscall.STD_ERROR_HANDLE, windows.STD_ERROR_HANDLE:
 		file = os.Stderr
 	default:
 		panic(fmt.Errorf("Invalid standard handle identifier: %v", nFile))


### PR DESCRIPTION
Commit 3ee0038cec469c02f7a130c7824d74a442330f35 (https://github.com/Azure/go-ansiterm/pull/31) updated the switch with the intent to handle either syscall.XX or golang.org/x/sys/win.XX values.

However, Go "switch" does not have an implicit "fallthrough" behavior, and either requires the "fallthrough" keyword to be used, or to combine values in a single "case".

For example, the following:

    for _, v := range []int{1, 2, 3, 4, 5, 6, 7} {
        result := "unknown"
        switch v {
        case 1: // doesn't fall-through, so this is an empty "case"
        case 2:
            result = "found one or two"
        case 3:
            fallthrough // falls through to "case 4"
        case 4:
            result = "found three or four"
        case 5, 6: // matches either 5 or 6
            result = "found five or six"
        default:
            result = "found something else"
        }
        fmt.Printf("%d: %s\n", v, result)
    }

Will print:

    1: unknown
    2: found one or two
    3: found three or four
    4: found three or four
    5: found five or six
    6: found five or six
    7: found something else

This patch combines "equal" values in a single case within the switch to
fix this issue.
