### PR TITLE
Fix OSC string terminator parsing

### DIFF
--- a/osc_string_state.go
+++ b/osc_string_state.go
@@ -11,21 +11,13 @@ func (oscState oscStringState) Handle(b byte) (s state, e error) {
 		return nextState, err
 	}
 
-	switch {
-	case isOscStringTerminator(b):
+	// There are several control characters and sequences which can
+	// terminate an OSC string. Most of them are handled by the baseState
+	// handler. The ANSI_BEL character is a special case which behaves as a
+	// terminator only for an OSC string.
+	if b == ANSI_BEL {
 		return oscState.parser.ground, nil
 	}
 
 	return oscState, nil
-}
-
-// See below for OSC string terminators for linux
-// http://man7.org/linux/man-pages/man4/console_codes.4.html
-func isOscStringTerminator(b byte) bool {
-
-	if b == ANSI_BEL || b == 0x5C {
-		return true
-	}
-
-	return false
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -15,8 +15,9 @@ func TestStateTransitions(t *testing.T) {
 	stateTransitionHelper(t, "EscapeIntermediate", "EscapeIntermediate", intermeds)
 	stateTransitionHelper(t, "EscapeIntermediate", "EscapeIntermediate", executors)
 	stateTransitionHelper(t, "EscapeIntermediate", "Ground", escapeIntermediateToGroundBytes)
-	stateTransitionHelper(t, "OscString", "Ground", []byte{ANSI_BEL})
-	stateTransitionHelper(t, "OscString", "Ground", []byte{0x5C})
+	stateTransitionHelper(t, "OscString", "Ground", []byte{ANSI_BEL, 0x9C})
+	stateTransitionHelper(t, "OscString", "OscString", printables)
+	stateTransitionHelper(t, "OscString", "Escape", []byte{ANSI_ESCAPE_PRIMARY})
 	stateTransitionHelper(t, "Ground", "Ground", executors)
 }
 

--- a/parser_test_helpers_test.go
+++ b/parser_test_helpers_test.go
@@ -17,28 +17,38 @@ func getStateNames() []string {
 }
 
 func stateTransitionHelper(t *testing.T, start string, end string, bytes []byte) {
+	t.Helper()
 	for _, b := range bytes {
-		bytes := []byte{byte(b)}
-		parser, _ := createTestParser(start)
-		parser.Parse(bytes)
-		validateState(t, parser.currState, end)
+		t.Run(fmt.Sprintf("Start=%s/%q", start, b), func(t *testing.T) {
+			t.Helper()
+			bytes := []byte{byte(b)}
+			parser, _ := createTestParser(start)
+			parser.Parse(bytes)
+			validateState(t, parser.currState, end)
+		})
 	}
 }
 
 func anyToXHelper(t *testing.T, bytes []byte, expectedState string) {
+	t.Helper()
 	for _, s := range getStateNames() {
 		stateTransitionHelper(t, s, expectedState, bytes)
 	}
 }
 
 func funcCallParamHelper(t *testing.T, bytes []byte, start string, expected string, expectedCalls []string) {
-	parser, evtHandler := createTestParser(start)
-	parser.Parse(bytes)
-	validateState(t, parser.currState, expected)
-	validateFuncCalls(t, evtHandler.FunctionCalls, expectedCalls)
+	t.Helper()
+	t.Run(fmt.Sprintf("Start=%s/%q", start, bytes), func(t *testing.T) {
+		t.Helper()
+		parser, evtHandler := createTestParser(start)
+		parser.Parse(bytes)
+		validateState(t, parser.currState, expected)
+		validateFuncCalls(t, evtHandler.FunctionCalls, expectedCalls)
+	})
 }
 
 func parseParamsHelper(t *testing.T, bytes []byte, expectedParams []string) {
+	t.Helper()
 	params, err := parseParams(bytes)
 
 	if err != nil {
@@ -63,6 +73,7 @@ func parseParamsHelper(t *testing.T, bytes []byte, expectedParams []string) {
 }
 
 func cursorSingleParamHelper(t *testing.T, command byte, funcName string) {
+	t.Helper()
 	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
 	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
 	funcCallParamHelper(t, []byte{'2', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2])", funcName)})
@@ -72,6 +83,7 @@ func cursorSingleParamHelper(t *testing.T, command byte, funcName string) {
 }
 
 func cursorTwoParamHelper(t *testing.T, command byte, funcName string) {
+	t.Helper()
 	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1 1])", funcName)})
 	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1 1])", funcName)})
 	funcCallParamHelper(t, []byte{'2', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([2 1])", funcName)})
@@ -81,6 +93,7 @@ func cursorTwoParamHelper(t *testing.T, command byte, funcName string) {
 }
 
 func eraseHelper(t *testing.T, command byte, funcName string) {
+	t.Helper()
 	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([0])", funcName)})
 	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([0])", funcName)})
 	funcCallParamHelper(t, []byte{'1', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
@@ -91,6 +104,7 @@ func eraseHelper(t *testing.T, command byte, funcName string) {
 }
 
 func scrollHelper(t *testing.T, command byte, funcName string) {
+	t.Helper()
 	funcCallParamHelper(t, []byte{command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
 	funcCallParamHelper(t, []byte{'0', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
 	funcCallParamHelper(t, []byte{'1', command}, "CsiEntry", "Ground", []string{fmt.Sprintf("%s([1])", funcName)})
@@ -99,6 +113,7 @@ func scrollHelper(t *testing.T, command byte, funcName string) {
 }
 
 func clearOnStateChangeHelper(t *testing.T, start string, end string, bytes []byte) {
+	t.Helper()
 	p, _ := createTestParser(start)
 	fillContext(p.context)
 	p.Parse(bytes)
@@ -107,6 +122,7 @@ func clearOnStateChangeHelper(t *testing.T, start string, end string, bytes []by
 }
 
 func c0Helper(t *testing.T, bytes []byte, expectedState string, expectedCalls []string) {
+	t.Helper()
 	parser, evtHandler := createTestParser("Ground")
 	parser.Parse(bytes)
 	validateState(t, parser.currState, expectedState)

--- a/parser_test_utilities_test.go
+++ b/parser_test_utilities_test.go
@@ -12,6 +12,7 @@ func createTestParser(s string) (*AnsiParser, *TestAnsiEventHandler) {
 }
 
 func validateState(t *testing.T, actualState state, expectedStateName string) {
+	t.Helper()
 	actualName := "Nil"
 
 	if actualState != nil {
@@ -24,6 +25,7 @@ func validateState(t *testing.T, actualState state, expectedStateName string) {
 }
 
 func validateFuncCalls(t *testing.T, actualCalls []string, expectedCalls []string) {
+	t.Helper()
 	actualCount := len(actualCalls)
 	expectedCount := len(expectedCalls)
 
@@ -50,6 +52,7 @@ func fillContext(context *ansiContext) {
 }
 
 func validateEmptyContext(t *testing.T, context *ansiContext) {
+	t.Helper()
 	var expectedCurrChar byte = 0x0
 	if context.currentChar != expectedCurrChar {
 		t.Errorf("Currentchar mismatch '%#x' != '%#x'", context.currentChar, expectedCurrChar)


### PR DESCRIPTION
* Fixes #34 

The OSC-string state handler was incorrectly transitioning to the ground state on any 0x5C byte. 0x5C is the backslash character `\`, which is a printable character and valid to include inside of an OSC string. Fix the parser so that no printable characters are interpreted as OSC terminators.